### PR TITLE
Replace depreciated SimpleBlock

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-numpy
-Pyomo
+Numpy
+Pyomo<=6.0

--- a/romodel/uncset/base.py
+++ b/romodel/uncset/base.py
@@ -1,10 +1,10 @@
-from pyomo.core import SimpleBlock, ModelComponentFactory, Component
+from pyomo.core import ScalarBlock, ModelComponentFactory, Component
 from pyomo.core import Constraint
 from romodel.uncparam import UncParam
 
 
 @ModelComponentFactory.register("Uncertainty set in a robust problem")
-class UncSet(SimpleBlock):
+class UncSet(ScalarBlock):
     """
     This model component defines an uncertainty set in a robust optimization
     problem.
@@ -18,10 +18,10 @@ class UncSet(SimpleBlock):
 
         # _var = kwargs.pop('var', None)
         #
-        # Initialize the SimpleBlock
+        # Initialize the ScalarBlock
         #
         kwargs.setdefault('ctype', UncSet)
-        SimpleBlock.__init__(self, *args, **kwargs)
+        ScalarBlock.__init__(self, *args, **kwargs)
         #
         # Initialize from kwargs
         #


### PR DESCRIPTION
Previously ```UncSet``` was derived from ```SimpleBlock``` which has depreciated in versions of Pyomo ```>=6.0``` (See [#2058](https://github.com/Pyomo/pyomo/pull/2058)). Resulting in the following warning:

```
WARNING: DEPRECATED: the 'SimpleBlock' class has been moved to
    'pyomo.core.base.block.SimpleBlock'.  Please update your import.
    (deprecated in 6.0) (called from /opt/miniconda3/lib/python3.9/site-
    packages/romodel/uncset/base.py:1)
WARNING: DEPRECATED: Declaring class 'UncSet' derived from 'SimpleBlock'.  The
    class 'SimpleBlock' has been renamed to 'ScalarBlock'.  (deprecated in
    6.0) (called from /opt/miniconda3/lib/python3.9/site-
    packages/romodel/uncset/base.py:7)
```
Therefore:
- Changed references to the new ```ScalarBlock``` class. 
- Updated ```requirements.txt``` to use Pyomo 6.0 or greater. 

This now does not produce this error when running on Pyomo 6.2.
