### PR TITLE
fixed pyomo release compatibility issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Numpy
-Pyomo<=6.0
+Pyomo==6.0
+pyutilib

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,11 @@ from setuptools import setup, find_packages
 
 setup(
     name='romodel',
-    version='0.0.2',
+    version='0.1.0',
     url='https://github.com/johwiebe/romodel.git',
     author='Johannes Wiebe',
     author_email='j.wiebe17@imperial.ac.uk',
     description='Pyomo robust optimization toolbox',
     packages=find_packages(),
-    install_requires=['pyomo', 'numpy'],
+    install_requires=['pyomo==6.0', 'numpy', 'pyutilib'],
 )


### PR DESCRIPTION
So I tried to install romodel and noticed pyomo version compatibility issues:
1) pyomo==6.0 does not require pytulib -> added to requirements and setup.py
2) pyomo==5.7.3. does not support ScalarBlock -> latest commit does not work
3) pyomo 6.4.2 throws an error  in romodel/uncparam.py constructor 
`AttributeError: 'IndexedUncParam' object has no attribute '_index'`

Therefore I updated setup.py and requirements with pyomo == 6.0 and pyutilib. Works on windows 10 and python 3.10 w_th gurobi. 

Additionally updated the version to the latest romodel release v0.1.0